### PR TITLE
Pin development dependencies

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,6 @@
 [paths]
 source =
    src/fx_sig_verify
-   */site-packages/fx_sig_verify
 
 [run]
 branch = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
+    - BOTO_CONFIG=/dev/null
   matrix:
     - TOXENV=check
       # - TOXENV=docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ env:
     - BOTO_CONFIG=/dev/null
   matrix:
     - TOXENV=check
-      # - TOXENV=docs
+    - TOXENV=docs
 
       # - TOXENV=py27,report,coveralls,codecov
-      #- TOXENV=py27,report,codecov
+    - TOXENV=py27,report,codecov
 
 before_install:
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
-    - BOTO_CONFIG=/dev/null
   matrix:
     - TOXENV=check
     - TOXENV=docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ install:
   - easy_install --version
   - pip --version
   - tox --version
+  - env
+  - ls -l /etc/boto.cfg ~/.boto
+  - echo "config :$BOTO_CONFIG: path :$BOTO_PATH:"
 script:
   - tox -v
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ env:
     - SEGFAULT_SIGNALS=all
   matrix:
     - TOXENV=check
-    - TOXENV=docs
+      # - TOXENV=docs
 
       # - TOXENV=py27,report,coveralls,codecov
-    - TOXENV=py27,report,codecov
+      #- TOXENV=py27,report,codecov
 
 before_install:
   - python --version
@@ -24,8 +24,8 @@ install:
   - tox --version
   - env
   - ls -l /etc/boto.cfg || true
-  - echo "config :$BOTO_CONFIG: path :$BOTO_PATH:"
   - test -r /etc/boto.cfg && cat /etc/boto.cfg
+  - echo "config '$BOTO_CONFIG' path '$BOTO_PATH'"
 script:
   - tox -v
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,9 @@ install:
   - pip --version
   - tox --version
   - env
-  - ls -l /etc/boto.cfg ~/.boto
+  - ls -l /etc/boto.cfg || true
   - echo "config :$BOTO_CONFIG: path :$BOTO_PATH:"
+  - test -r /etc/boto.cfg && cat /etc/boto.cfg
 script:
   - tox -v
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ install:
   - easy_install --version
   - pip --version
   - tox --version
-  - env
-  - ls -l /etc/boto.cfg || true
-  - test -r /etc/boto.cfg && cat /etc/boto.cfg
-  - echo "config '$BOTO_CONFIG' path '$BOTO_PATH'"
 script:
   - tox -v
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - uname -a
   - lsb_release -a
 install:
-  - pip install tox
+  - pip install tox==2.9.1
   - virtualenv --version
   - easy_install --version
   - pip --version

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,93 @@
-appdirs
-boto3
-docutils
-futures
-jmespath
-packaging
-pyparsing
-python-dateutil
-pytest
-s3transfer
-six
+# pin versions of our top level requirements
+appdirs==1.4.3
+boto3==1.7.62
+docutils==0.14
+futures==3.2.0
+jmespath==0.9.3
+packaging==17.1
+pyparsing==2.2.0
+python-dateutil==2.7.3
+pytest==3.6.3
+s3transfer==0.1.13
+six==1.11.0
 git+https://github.com/hwine/moto.git@pass-subject-through
+
+# pin versions of sub dependencies
+
+
+# Jinja2>=2.8 (from moto==1.1.23->-r requirements-dev.txt (line 12))
+Jinja2==2.10
+# boto>=2.36.0 (from moto==1.1.23->-r requirements-dev.txt (line 12))
+boto==2.49.0
+# botocore>=1.7.12 (from moto==1.1.23->-r requirements-dev.txt (line 12))
+botocore==1.10.62
+# cookies (from moto==1.1.23->-r requirements-dev.txt (line 12))
+cookies==2.2.1
+# cryptography>=2.0.0 (from moto==1.1.23->-r requirements-dev.txt (line 12))
+cryptography==2.3
+# requests>=2.5 (from moto==1.1.23->-r requirements-dev.txt (line 12))
+requests==2.19.1
+# xmltodict (from moto==1.1.23->-r requirements-dev.txt (line 12))
+xmltodict==0.11.0
+# werkzeug (from moto==1.1.23->-r requirements-dev.txt (line 12))
+Werkzeug==0.14.1
+# pyaml (from moto==1.1.23->-r requirements-dev.txt (line 12))
+pyaml==17.12.1
+# pytz (from moto==1.1.23->-r requirements-dev.txt (line 12))
+pytz==2018.5
+# mock (from moto==1.1.23->-r requirements-dev.txt (line 12))
+mock==2.0.0
+# docker>=2.5.1 (from moto==1.1.23->-r requirements-dev.txt (line 12))
+docker==3.4.1
+# aws-xray-sdk==0.92.2 (from moto==1.1.23->-r requirements-dev.txt (line 12))
+aws_xray_sdk==0.92.2
+# backports.tempfile (from moto==1.1.23->-r requirements-dev.txt (line 12))
+backports.tempfile==1.0
+# attrs>=17.4.0 (from pytest->-r requirements-dev.txt (line 9))
+attrs==18.1.0
+# funcsigs; python_version < "3.0" (from pytest->-r requirements-dev.txt (line 9))
+funcsigs==1.0.2
+# pluggy<0.7,>=0.5 (from pytest->-r requirements-dev.txt (line 9))
+pluggy==0.6.0
+# atomicwrites>=1.0 (from pytest->-r requirements-dev.txt (line 9))
+atomicwrites==1.1.5
+# more-itertools>=4.0.0 (from pytest->-r requirements-dev.txt (line 9))
+more_itertools==4.2.0
+# py>=1.5.0 (from pytest->-r requirements-dev.txt (line 9))
+py==1.5.4
+# MarkupSafe>=0.23 (from Jinja2>=2.8->moto==1.1.23->-r requirements-dev.txt (line 12))
+MarkupSafe==1.0
+# asn1crypto>=0.21.0 (from cryptography>=2.0.0->moto==1.1.23->-r requirements-dev.txt (line 12))
+asn1crypto==0.24.0
+# enum34; python_version < "3" (from cryptography>=2.0.0->moto==1.1.23->-r requirements-dev.txt (line 12))
+enum34==1.1.6
+# cffi!=1.11.3,>=1.7 (from cryptography>=2.0.0->moto==1.1.23->-r requirements-dev.txt (line 12))
+cffi==1.11.5
+# idna>=2.1 (from cryptography>=2.0.0->moto==1.1.23->-r requirements-dev.txt (line 12))
+idna==2.7
+# ipaddress; python_version < "3" (from cryptography>=2.0.0->moto==1.1.23->-r requirements-dev.txt (line 12))
+ipaddress==1.0.22
+# chardet<3.1.0,>=3.0.2 (from requests>=2.5->moto==1.1.23->-r requirements-dev.txt (line 12))
+chardet==3.0.4
+# urllib3<1.24,>=1.21.1 (from requests>=2.5->moto==1.1.23->-r requirements-dev.txt (line 12))
+urllib3==1.23
+# certifi>=2017.4.17 (from requests>=2.5->moto==1.1.23->-r requirements-dev.txt (line 12))
+certifi==2018.4.16
+# PyYAML (from pyaml->moto==1.1.23->-r requirements-dev.txt (line 12))
+PyYAML==3.13
+# pbr>=0.11 (from mock->moto==1.1.23->-r requirements-dev.txt (line 12))
+pbr==4.2.0
+# backports.ssl-match-hostname>=3.5; python_version < "3.5" (from docker>=2.5.1->moto==1.1.23->-r requirements-dev.txt (line 12))
+backports.ssl_match_hostname==3.5.0.1
+# websocket-client>=0.32.0 (from docker>=2.5.1->moto==1.1.23->-r requirements-dev.txt (line 12))
+websocket_client==0.48.0
+# docker-pycreds>=0.3.0 (from docker>=2.5.1->moto==1.1.23->-r requirements-dev.txt (line 12))
+docker_pycreds==0.3.0
+# wrapt (from aws-xray-sdk==0.92.2->moto==1.1.23->-r requirements-dev.txt (line 12))
+wrapt==1.10.11
+# jsonpickle (from aws-xray-sdk==0.92.2->moto==1.1.23->-r requirements-dev.txt (line 12))
+jsonpickle==0.9.6
+# backports.weakref (from backports.tempfile->moto==1.1.23->-r requirements-dev.txt (line 12))
+backports.weakref==1.0.post1
+# pycparser (from cffi!=1.11.3,>=1.7->cryptography>=2.0.0->moto==1.1.23->-r requirements-dev.txt (line 12))
+pycparser==2.18

--- a/tox.ini
+++ b/tox.ini
@@ -105,7 +105,8 @@ commands =
 deps = coverage
 skip_install = true
 commands =
-    coverage combine --append
+    # combine sometimes fails with no data
+    coverage combine --append || true
     coverage report
     coverage html
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
     XRAY_DISABLE=yes
+    BOTO_CONFIG=/dev/null
 usedevelop = false
 deps =
     ; first specification of package wins with pip, so put unqualified

--- a/tox.ini
+++ b/tox.ini
@@ -28,10 +28,11 @@ setenv =
     XRAY_DISABLE=yes
 usedevelop = false
 deps =
-    pytest
+    ; first specification of package wins with pip, so put unqualified
+    ; at end
+    -r{toxinidir}/requirements-dev.txt
     pytest-travis-fold
     pytest-cov
-    -r{toxinidir}/requirements-dev.txt
 commands =
     {posargs:py.test --cov --cov-report=term-missing -vv tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -105,8 +105,8 @@ commands =
 deps = coverage
 skip_install = true
 commands =
-    # combine sometimes fails with no data
-    coverage combine --append || true
+
+    # coverage combine --append <== nothing to combine at present
     coverage report
     coverage html
 


### PR DESCRIPTION
Fixes #52 

The production build process runs the tests, which uses the development
dependencies. The newer versions of the various mocking libraries are
not backward compatible, causing tests to fail.

Pinned to versions used in the last successful production build, per the
Jenkins logs. Everything works now \o/.