### PR TITLE
Add missing openssl dependency to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,13 @@ Development
 
 At present, ``fx-sig-verify`` is python 2.7 only.
 
-Typical development setup, using a local virtual environment::
+Install Openssl dependencies::
+
+    sudo apt install libssl1.0-dev # Ubuntu or
+
+    sudo dnf install compat-openssl10-devel # Fedora
+
+And for the Python, a typical development setup. Using a local virtual environment::
 
     git clone https://github.com/mozilla-services/fx-sig-verify
     cd fx-sig-verify


### PR DESCRIPTION
Closes #76

I've added the instructions for installing the needed Openssl packages at Ubuntu and Fedora to `README.rst`.

For Fedora I tested on my personal environment, with Fedora 31. And for the Ubuntu I've tested at a clean Docker container running the official Ubuntu image with Ubuntu 18.04.4. 